### PR TITLE
fix: remove sourcehut:~reggie/licenses.nvim

### DIFF
--- a/data/plugins-info/awesome-neovim.json
+++ b/data/plugins-info/awesome-neovim.json
@@ -66,17 +66,6 @@
     "url": "https://git.sr.ht/~nedia/auto-save.nvim/archive/24af023800c48645e6472cb6f30cebe782288446.tar.gz"
   },
   {
-    "date": "2024-01-03",
-    "description": "Insert and write license headers and/or files.",
-    "homepage": "https://git.sr.ht/~reggie/licenses.nvim",
-    "owner": "~reggie",
-    "repo": "licenses.nvim",
-    "rev": "097c69f66505479b1f3fc3a051f4f9528abcb345",
-    "sha256": "0wxkmpbnbsbz73cfkhr9h70sx4jmh7xvabglz22d67jk7y8apqy8",
-    "site": "git.sr.ht",
-    "url": "https://git.sr.ht/~reggie/licenses.nvim/archive/097c69f66505479b1f3fc3a051f4f9528abcb345.tar.gz"
-  },
-  {
     "date": "2024-03-09",
     "description": "Show nvim diagnostics using virtual lines",
     "homepage": "https://git.sr.ht/~whynothugo/lsp_lines.nvim",

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -65,7 +65,6 @@ let
           nvim-startup-lua = mit;
           auto-format-nvim = mit;
           nedia-auto-save-nvim = mit;
-          licenses-nvim = mit;
           lsp-lines-nvim = isc;
           distinct-nvim = mit;
           halfspace-nvim = mit;


### PR DESCRIPTION
Not sure but the repository of licenses.nvim has been removed.
This patch should fix recent failure to update plugins:

https://github.com/m15a/flake-awesome-neovim-plugins/actions/runs/10202787423/job/28227685529#step:6:27